### PR TITLE
Add temporary Supabase debug output

### DIFF
--- a/supabase_client.py
+++ b/supabase_client.py
@@ -23,6 +23,10 @@ load_dotenv()
 SUPABASE_URL = os.getenv("SUPABASE_URL", "")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY", "")
 
+# Temporary debug output to verify credentials are loaded correctly
+print("SUPABASE_URL:", SUPABASE_URL)
+print("SUPABASE_KEY:", SUPABASE_KEY)
+
 
 def _is_dummy(value: str) -> bool:
     return not value or value.lower() == "dummy"
@@ -64,11 +68,13 @@ class LazySupabase:
     def __init__(self) -> None:
         self._client: Client | None = None
         self.dummy = _is_dummy(SUPABASE_URL) or _is_dummy(SUPABASE_KEY)
+        print("Dummy mode:", self.dummy)
 
     def _ensure_client(self) -> Client | _DummySupabase:
         if self.dummy:
             return _DummySupabase()
         if self._client is None:
+            print("Creating Supabase client")
             self._client = create_client(SUPABASE_URL, SUPABASE_KEY)
         return self._client
 


### PR DESCRIPTION
## Summary
- print Supabase credentials on import to verify environment variables
- log when the Supabase client is created
- log start command and insertion attempts
- log registration save operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68614efc9c8c8325a4b53d65b11387c8