### PR TITLE
Add temporary Supabase debug output

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,6 +59,8 @@ WEBHOOK_URL = f"{WEBHOOK_HOST}{WEBHOOK_PATH}" if WEBHOOK_HOST else None
 START_TIME = time.perf_counter()
 
 BOT_DUMMY = not BOT_TOKEN or BOT_TOKEN.lower() == "dummy"
+logger.info("BOT_DUMMY: %s", BOT_DUMMY)
+logger.info("Supabase dummy: %s", supabase.dummy)
 if IS_PROD and not WEBHOOK_HOST:
     raise ValueError("❌ WEBHOOK_HOST не найден в .env для продакшена!")
 

--- a/registration.py
+++ b/registration.py
@@ -47,6 +47,7 @@ async def user_exists(telegram_id: int) -> bool:
 @router.message(Command("start"))
 async def start_cmd(message: Message, state: FSMContext) -> None:
     StatsLogger.log(event="start_command")
+    logger.info("start_cmd invoked for user %s", message.from_user.id)
 
     user_id = message.from_user.id
     username = message.from_user.username or ""
@@ -61,6 +62,7 @@ async def start_cmd(message: Message, state: FSMContext) -> None:
         )
         if not getattr(result, "data", []):
             StatsLogger.log(event="register_user_attempt", telegram_id=user_id)
+            logger.info("Inserting new user %s into Supabase", user_id)
             await with_supabase_retry(
                 lambda: supabase.table("users").insert(
                     {
@@ -73,6 +75,7 @@ async def start_cmd(message: Message, state: FSMContext) -> None:
                     }
                 ).execute()
             )
+            logger.info("Insert completed")
     except Exception as e:
         logger.warning(f"Failed to ensure user in Supabase: {e}")
         StatsLogger.log(event="supabase_error", message=str(e))
@@ -134,6 +137,7 @@ async def _finish_registration(message: Message, state: FSMContext, phone: str) 
         telegram_id=message.from_user.id,
         username=message.from_user.username,
     )
+    logger.info("Saving user %s to Supabase", message.from_user.id)
     try:
         await with_supabase_retry(
             lambda: supabase.table("users").insert(
@@ -147,6 +151,7 @@ async def _finish_registration(message: Message, state: FSMContext, phone: str) 
                 }
             ).execute()
         )
+        logger.info("Insert completed")
         StatsLogger.log(event="registration_success")
     except Exception as e:
         logger.exception(f"Failed to save user: {e}")

--- a/supabase_client.py
+++ b/supabase_client.py
@@ -23,6 +23,10 @@ load_dotenv()
 SUPABASE_URL = os.getenv("SUPABASE_URL", "")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY", "")
 
+# Temporary debug output to verify credentials are loaded correctly
+logger.info("SUPABASE_URL present: %s", bool(SUPABASE_URL))
+logger.info("SUPABASE_KEY present: %s", bool(SUPABASE_KEY))
+
 
 def _is_dummy(value: str) -> bool:
     return not value or value.lower() == "dummy"
@@ -64,11 +68,13 @@ class LazySupabase:
     def __init__(self) -> None:
         self._client: Client | None = None
         self.dummy = _is_dummy(SUPABASE_URL) or _is_dummy(SUPABASE_KEY)
+        logger.info("Dummy mode: %s", self.dummy)
 
     def _ensure_client(self) -> Client | _DummySupabase:
         if self.dummy:
             return _DummySupabase()
         if self._client is None:
+            logger.info("Creating Supabase client")
             self._client = create_client(SUPABASE_URL, SUPABASE_KEY)
         return self._client
 


### PR DESCRIPTION
## Summary
- print Supabase credentials on import to verify environment variables
- log when the Supabase client is created
- log start command and insertion attempts
- log registration save operations
- log when dummy mode is used
- mask credentials in debug logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py 2>&1 | head`


------
https://chatgpt.com/codex/tasks/task_e_68614efc9c8c8325a4b53d65b11387c8